### PR TITLE
Adds workaround for maturity endpoint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: A programmatic interface to http://www.fishbase.org, re-written
     supports experimental access to http://www.sealifebase.org data, which contains
     nearly 200,000 species records for all types of aquatic life not covered by
     'FishBase.'
-Version: 2.1.0
+Version: 2.1.0.1
 License: CC0
 Authors@R: c(person("Carl", "Boettiger", role = c("cre", "aut"), email = "cboettig@ropensci.org"),
              person("Scott", "Chamberlain", role = "aut", email = "scott@ropensci.org"),

--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,6 @@ package vignette for a more detailed overview and introduction.
 v2.0.1.1
 -----
 
-* bugfix for maturity endpoint: now properly queries by input species list
+* bugfix for endpoints with inconsistent spelling of SpecCode column (e.g. maturity, diet, ecosystem, morphology, morphometrics, popchar, poplf). Now properly queries by input species list
 
 

--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,8 @@ package vignette for a more detailed overview and introduction.
 v2.0.1.1
 -----
 
-* bugfix for endpoints with inconsistent spelling of SpecCode column (e.g. maturity, diet, ecosystem, morphology, morphometrics, popchar, poplf). Now properly queries by input species list
+* bugfix for endpoints with inconsistent spelling of SpecCode column 
+(e.g. maturity, diet, ecosystem, morphology, morphometrics, popchar, poplf).
+Now properly queries by input species list
 
 

--- a/NEWS
+++ b/NEWS
@@ -51,4 +51,9 @@ First official release of the new rfishbase package, a non-backwards
 compatible replacement to all earlier versions of FishBase. See the
 package vignette for a more detailed overview and introduction.
 
+v2.0.1.1
+-----
+
+* bugfix for maturity endpoint: now properly queries by input species list
+
 

--- a/R/00-endpoint.R
+++ b/R/00-endpoint.R
@@ -13,13 +13,21 @@ endpoint <- function(endpt, tidy_table = default_tidy){
         args <- c(args, 
                   fields = paste(c("SpecCode", fields), 
                                  collapse=","))
-       
+      
+      # Workaround for inconsistent name in maturity endpoint 
+      if(endpt == "maturity"){
+        names(args)[names(args) == "SpecCode"] = "Speccode"
+      }
       
       resp <- httr::GET(paste0(server, "/", endpt), 
                         query = args, 
                         ..., 
                         httr::user_agent(make_ua()))
       data <- check_and_parse(resp)
+      
+      if(endpt == "maturity"){
+        names(data)[names(data) == "Speccode"] = "SpecCode"
+      }
       
       tidy_table(data, server = server)
     }))

--- a/R/00-endpoint.R
+++ b/R/00-endpoint.R
@@ -14,8 +14,9 @@ endpoint <- function(endpt, tidy_table = default_tidy){
                   fields = paste(c("SpecCode", fields), 
                                  collapse=","))
       
-      # Workaround for inconsistent name in maturity endpoint 
-      if(endpt == "maturity"){
+      # Workaround for inconsistent names in certain endpoints
+      bad_tables = c('diet', 'ecosystem', 'maturity', 'morphdat', 'morphmet', 'popchar', 'poplf')
+      if(endpt %in% bad_tables){
         names(args)[names(args) == "SpecCode"] = "Speccode"
       }
       
@@ -25,7 +26,7 @@ endpoint <- function(endpt, tidy_table = default_tidy){
                         httr::user_agent(make_ua()))
       data <- check_and_parse(resp)
       
-      if(endpt == "maturity"){
+      if(endpt %in% bad_tables){
         names(data)[names(data) == "Speccode"] = "SpecCode"
       }
       

--- a/tests/testthat/test_maturity.R
+++ b/tests/testthat/test_maturity.R
@@ -1,0 +1,8 @@
+context("maturity")
+
+test_that('returns a data.frame with correct sciname', 
+          {
+            needs_api()
+            expect_true("Epinephelus morio" %in% maturity("Epinephelus morio")$sciname)
+          }
+          )


### PR DESCRIPTION
maturity endpoint has column "Speccode" instead of "SpecCode" used in the other endpoints. This works around that difference by converting back and forth between the names