### PR TITLE
enable load_taxa for sealifebase, close #79

### DIFF
--- a/R/load_taxa.R
+++ b/R/load_taxa.R
@@ -1,6 +1,6 @@
 
 
-## Create an environment to cache the full speices table
+## Create an environment to cache the full species table
 rfishbase <- new.env(hash = TRUE)
 
 
@@ -39,7 +39,7 @@ load_taxa <- function(update = FALSE, cache = TRUE, server = getOption("FISHBASE
     if(update){
       
       resp <- GET(paste0(server, "/taxa"), 
-                  query = list(family='', limit=as.integer(limit)), 
+                  query = list(limit=as.integer(limit)), 
                   user_agent(make_ua()))
       all_taxa <- check_and_parse(resp)
       drop <- match(c("Author", "Remark"), names(all_taxa)) ## Non-ascii fields, not needed


### PR DESCRIPTION
In an attempt to get the sealifebase to update (#79), I've taken out the ```family = '' "``` statement from the server query in ```load_taxa```, this seems to fix the sealifebase query (it was still returning NULL despite ropensci/fishbaseapi#84 being closed). Not sure if this is a useful fix - I tested it with fishbase and sealifebase and it seems to work fine for both.