### PR TITLE
fix to endpoint() internals to get unique set of results

### DIFF
--- a/R/00-endpoint.R
+++ b/R/00-endpoint.R
@@ -5,7 +5,7 @@
 endpoint <- function(endpt, tidy_table = default_tidy){
   
   function(species_list, fields = NULL, limit = 200, server = getOption("FISHBASE_API", FISHBASE_API), ...){
-    codes <- speccodes(species_list)
+    codes <- unique(speccodes(species_list))
     dplyr::bind_rows(lapply(codes, function(code){
       args <- list(SpecCode = code,
                    limit = limit)
@@ -39,7 +39,7 @@ endpoint <- function(endpt, tidy_table = default_tidy){
 default_tidy <- function(x, server = getOption("FISHBASE_API", FISHBASE_API)){
   if("SpecCode" %in% names(x)){
     code <- x$SpecCode
-    x$SpecCode <- species_names(code, server = server)
+    x$SpecCode <- unique(species_names(code, server = server))
     names(x)[names(x) == "SpecCode"] <- "sciname"
     x <- cbind(x, SpecCode = code)
   }


### PR DESCRIPTION
and unique set results in `default_tidy` internal fxn

fix #83 