### PR TITLE
add possibility to load entire table in single or looped API call from endpoint

### DIFF
--- a/R/00-endpoint.R
+++ b/R/00-endpoint.R
@@ -7,11 +7,12 @@ endpoint <- function(endpt, tidy_table = default_tidy){
   function(species_list=NULL, fields = NULL, query = NULL, limit = 200, server = getOption("FISHBASE_API", FISHBASE_API), ...){
     
     codes <- speccodes(species_list, all_taxa = load_taxa(server=server))
+    
     if(is.list(codes) && length(codes)>0) {# partial match
-      warning(paste(length(codes[lapply(codes, length)>1]),'of the supplied species names match species in fishbase: \n'),paste(species_list[unlist(lapply(codes, length)>1)], collapse = '\n')) 
+      warning(paste(length(codes[lapply(codes, length)>1]),'of the supplied species names did not match any species in the database: \n'),paste(species_list[unlist(lapply(codes, length)>1)], collapse = '\n')) 
       codes <- unique(codes[lapply(codes, length)==1])
     } else if(is.matrix(codes)) { # no match
-      stop('None of the supplied species names match species in fishbase') 
+      stop('None of the supplied species names match any species in the database') 
     } else if (length(codes) == 0) { # return table up to limit
       codes = ''
       warning('No species list supplied: retrieving data up to limit')

--- a/R/00-endpoint.R
+++ b/R/00-endpoint.R
@@ -9,12 +9,14 @@ endpoint <- function(endpt, tidy_table = default_tidy){
     codes <- speccodes(species_list)
     if(is.list(codes) && length(codes)>0) {# partial match
       warning(paste(length(codes[lapply(codes, length)>1]),'of the supplied species names match species in fishbase: \n'),paste(species_list[unlist(lapply(codes, length)>1)], collapse = '\n')) 
-      codes <- codes[lapply(codes, length)==1]
+      codes <- unique(codes[lapply(codes, length)==1])
     } else if(is.matrix(codes)) { # no match
       stop('None of the supplied species names match species in fishbase') 
     } else if (length(codes) == 0) { # return table up to limit
       codes = ''
       warning('No species list supplied: retrieving data up to limit')
+    } else {
+      codes <- unique(codes)
     }
     
     dplyr::bind_rows(lapply(codes, function(code){

--- a/R/00-endpoint.R
+++ b/R/00-endpoint.R
@@ -4,29 +4,74 @@
 #' @importFrom dplyr bind_rows
 endpoint <- function(endpt, tidy_table = default_tidy){
   
-  function(species_list, fields = NULL, limit = 200, server = getOption("FISHBASE_API", FISHBASE_API), ...){
+  function(species_list=NULL, fields = NULL, limit = 200, server = getOption("FISHBASE_API", FISHBASE_API), ...){
+    
     codes <- speccodes(species_list)
+    if(is.list(codes) && length(codes)>0) {# partial match
+      warning(paste(length(codes[lapply(codes, length)>1]),'of the supplied species names match species in fishbase: \n'),paste(species_list[unlist(lapply(codes, length)>1)], collapse = '\n')) 
+      codes <- codes[lapply(codes, length)==1]
+    } else if(is.matrix(codes)) { # no match
+      stop('None of the supplied species names match species in fishbase') 
+    } else if (length(codes) == 0) { # return table up to limit
+      codes = ''
+      warning('No species list supplied: retrieving data up to limit')
+    }
+    
     dplyr::bind_rows(lapply(codes, function(code){
-      args <- list(SpecCode = code,
-                   limit = limit)
-      if(!is.null(fields)) 
-        args <- c(args, 
-                  fields = paste(c("SpecCode", fields), 
-                                 collapse=","))
       
-      # Workaround for inconsistent names in certain endpoints
-      bad_tables = c('diet', 'ecosystem', 'maturity', 'morphdat', 'morphmet', 'popchar', 'poplf')
-      if(endpt %in% bad_tables){
-        names(args)[names(args) == "SpecCode"] = "Speccode"
+      # only do this if no species supplied
+      if(nchar(code)==0 && limit>5000){
+        k <- 0
+        data <- {}
+        while(k<limit){
+          
+          args <- list(SpecCode = code,
+                       limit = as.integer(min(5000,limit-k)), 
+                       offset=as.integer(k+1))
+          if(!is.null(fields)) 
+            args <- c(args, 
+                      fields = paste(c("SpecCode", fields), 
+                                     collapse=","))
+          
+          # Workaround for inconsistent names in certain endpoints
+          bad_tables = c('diet', 'ecosystem', 'maturity', 'morphdat', 'morphmet', 'popchar', 'poplf')
+          if(endpt %in% bad_tables){
+            names(args)[names(args) == "SpecCode"] = "Speccode"
+          }
+          
+          resp <- httr::GET(paste0(server, "/", endpt), 
+                            query = args, 
+                            ..., 
+                            httr::user_agent(make_ua()))
+          tmp_data <- check_and_parse(resp)
+          k <- k+5000
+          data <- rbind(data,tmp_data)          
+        }
+      } else {
+        
+        args <- list(SpecCode = code,
+                     limit = limit)
+        if(!is.null(fields)) 
+          args <- c(args, 
+                    fields = paste(c("SpecCode", fields), 
+                                   collapse=","))
+        
+        # Workaround for inconsistent names in certain endpoints
+        bad_tables = c('diet', 'ecosystem', 'maturity', 'morphdat', 'morphmet', 'popchar', 'poplf')
+        if(endpt %in% bad_tables){
+          names(args)[names(args) == "SpecCode"] = "Speccode"
+        }
+        
+        resp <- httr::GET(paste0(server, "/", endpt), 
+                          query = args, 
+                          ..., 
+                          httr::user_agent(make_ua()))
+        data <- check_and_parse(resp)
+        
       }
       
-      resp <- httr::GET(paste0(server, "/", endpt), 
-                        query = args, 
-                        ..., 
-                        httr::user_agent(make_ua()))
-      data <- check_and_parse(resp)
-      
-      if(endpt %in% bad_tables){
+      # this fails if returned data is NULL
+      if(endpt %in% bad_tables && !is.null(data)){
         names(data)[names(data) == "Speccode"] = "SpecCode"
       }
       

--- a/R/species.R
+++ b/R/species.R
@@ -1,7 +1,7 @@
 #' species
 #' 
 #' Provide wrapper to work with species lists. 
-#' @param species_list A vector of scientific names (each element as "genus species"). 
+#' @param species_list A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.
 #' @param limit The maximum number of matches from a single API call (e.g. per species). Function
 #'   will warn if this needs to be increased, otherwise can be left as is. 
 #' @param server base URL to the FishBase API (by default). For SeaLifeBase, use http://fishbase.ropensci.org/sealifebase

--- a/R/species.R
+++ b/R/species.R
@@ -6,8 +6,9 @@
 #'   will warn if this needs to be increased, otherwise can be left as is. 
 #' @param server base URL to the FishBase API (by default). For SeaLifeBase, use http://fishbase.ropensci.org/sealifebase
 #' @param fields a character vector specifying which fields (columns) should be returned. By default,
-#'  all available columns recognized by the parser are returned. This option can be used to the amount
-#'  of data transfered over the network if only certain columns are needed.  
+#'  all available columns recognized by the parser are returned. This option can be used to limit the amount
+#'  of data transfered over the network if only certain columns are needed. 
+#' @param query a named list specifying specific subsets of fields.
 #' @param ... additional arguments to httr::GET
 #' @return a data.frame with rows for species and columns for the fields returned by the query (FishBase 'species' table)
 #' @details 

--- a/R/trophic_ecology.R
+++ b/R/trophic_ecology.R
@@ -15,11 +15,11 @@
 #' ecology(c("Oreochromis niloticus", "Salmo trutta"),
 #'         fields=c("SpecCode", "FoodTroph", "FoodSeTroph", "DietTroph", "DietSeTroph"))
 #' }
-ecology <- function(species_list, fields = NULL, limit = 1, server = getOption("FISHBASE_API", FISHBASE_API)){
+ecology <- function(species_list=NULL, fields = NULL, query = NULL, limit = 1, server = getOption("FISHBASE_API", FISHBASE_API)){
   if(limit == 1) # don't bug user about missing returns
-    suppressWarnings(ecology_endpoint(species_list, fields = fields, limit = limit, server = server))
+    suppressWarnings(ecology_endpoint(species_list, fields = fields, query = query, limit = limit, server = server))
   else
-    ecology_endpoint(species_list, fields = fields, limit = limit, server = server)
+    ecology_endpoint(species_list, fields = fields, query = query, limit = limit, server = server)
 }
 
 ## This function wants to have custom default for the 'limit' argument.  To do this, first create 

--- a/man/c_code.Rd
+++ b/man/c_code.Rd
@@ -13,7 +13,7 @@ c_code(c_code, server = getOption("FISHBASE_API", FISHBASE_API),
 \item{server}{base URL to the FishBase API (by default). For SeaLifeBase, use http://fishbase.ropensci.org/sealifebase}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function

--- a/man/common_names.Rd
+++ b/man/common_names.Rd
@@ -20,7 +20,7 @@ will warn if this needs to be increased, otherwise can be left as is.}
 \item{Language}{a string specifying the language for the common name, e.g. "English"}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
 }
 \value{

--- a/man/common_names.Rd
+++ b/man/common_names.Rd
@@ -10,7 +10,7 @@ common_names(species_list, limit = 1000, server = getOption("FISHBASE_API",
   "C_Code", "SpecCode"))
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/country.Rd
+++ b/man/country.Rd
@@ -11,8 +11,10 @@ country(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/country.Rd
+++ b/man/country.Rd
@@ -4,11 +4,11 @@
 \alias{country}
 \title{country}
 \usage{
-country(species_list, fields = NULL, limit = 200,
+country(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/diet.Rd
+++ b/man/diet.Rd
@@ -11,8 +11,10 @@ diet(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/diet.Rd
+++ b/man/diet.Rd
@@ -4,11 +4,11 @@
 \alias{diet}
 \title{diet}
 \usage{
-diet(species_list, fields = NULL, limit = 200,
+diet(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/distribution.Rd
+++ b/man/distribution.Rd
@@ -8,7 +8,7 @@ distribution(species_list, server = getOption("FISHBASE_API", FISHBASE_API),
   limit = 500)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{server}{base URL to the FishBase API (by default). For SeaLifeBase, use http://fishbase.ropensci.org/sealifebase}
 

--- a/man/ecology.Rd
+++ b/man/ecology.Rd
@@ -4,15 +4,17 @@
 \alias{ecology}
 \title{ecology}
 \usage{
-ecology(species_list, fields = NULL, limit = 1,
+ecology(species_list = NULL, fields = NULL, query = NULL, limit = 1,
   server = getOption("FISHBASE_API", FISHBASE_API))
 }
 \arguments{
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/ecology.Rd
+++ b/man/ecology.Rd
@@ -8,7 +8,7 @@ ecology(species_list, fields = NULL, limit = 1,
   server = getOption("FISHBASE_API", FISHBASE_API))
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/ecosystem.Rd
+++ b/man/ecosystem.Rd
@@ -11,8 +11,10 @@ ecosystem(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/ecosystem.Rd
+++ b/man/ecosystem.Rd
@@ -4,11 +4,11 @@
 \alias{ecosystem}
 \title{ecosystem}
 \usage{
-ecosystem(species_list, fields = NULL, limit = 200,
+ecosystem(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/faoareas.Rd
+++ b/man/faoareas.Rd
@@ -8,7 +8,7 @@ faoareas(species_list, server = getOption("FISHBASE_API", FISHBASE_API),
   limit = 500)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{server}{base URL to the FishBase API (by default). For SeaLifeBase, use http://fishbase.ropensci.org/sealifebase}
 

--- a/man/fecundity.Rd
+++ b/man/fecundity.Rd
@@ -4,11 +4,11 @@
 \alias{fecundity}
 \title{fecundity}
 \usage{
-fecundity(species_list, fields = NULL, limit = 200,
+fecundity(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/fecundity.Rd
+++ b/man/fecundity.Rd
@@ -11,8 +11,10 @@ fecundity(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/fooditems.Rd
+++ b/man/fooditems.Rd
@@ -11,8 +11,10 @@ fooditems(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/fooditems.Rd
+++ b/man/fooditems.Rd
@@ -4,11 +4,11 @@
 \alias{fooditems}
 \title{fooditems}
 \usage{
-fooditems(species_list, fields = NULL, limit = 200,
+fooditems(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/heartbeat.Rd
+++ b/man/heartbeat.Rd
@@ -23,7 +23,8 @@ resp <- heartbeat()
 resp$times
 
 ## Show API endpoints:
-content(resp)
+library("httr")
+httr::content(resp)
 
 }
 }

--- a/man/introductions.Rd
+++ b/man/introductions.Rd
@@ -11,8 +11,10 @@ introductions(species_list = NULL, fields = NULL, query = NULL,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/introductions.Rd
+++ b/man/introductions.Rd
@@ -4,11 +4,11 @@
 \alias{introductions}
 \title{introductions}
 \usage{
-introductions(species_list, fields = NULL, limit = 200,
-  server = getOption("FISHBASE_API", FISHBASE_API), ...)
+introductions(species_list = NULL, fields = NULL, query = NULL,
+  limit = 200, server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/length_freq.Rd
+++ b/man/length_freq.Rd
@@ -5,11 +5,11 @@
 \alias{poplf}
 \title{length_freq}
 \usage{
-length_freq(species_list, fields = NULL, limit = 200,
-  server = getOption("FISHBASE_API", FISHBASE_API), ...)
+length_freq(species_list = NULL, fields = NULL, query = NULL,
+  limit = 200, server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/length_freq.Rd
+++ b/man/length_freq.Rd
@@ -12,8 +12,10 @@ length_freq(species_list = NULL, fields = NULL, query = NULL,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/length_length.Rd
+++ b/man/length_length.Rd
@@ -12,8 +12,10 @@ length_length(species_list = NULL, fields = NULL, query = NULL,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/length_length.Rd
+++ b/man/length_length.Rd
@@ -5,11 +5,11 @@
 \alias{popll}
 \title{length_length}
 \usage{
-length_length(species_list, fields = NULL, limit = 200,
-  server = getOption("FISHBASE_API", FISHBASE_API), ...)
+length_length(species_list = NULL, fields = NULL, query = NULL,
+  limit = 200, server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/length_weight.Rd
+++ b/man/length_weight.Rd
@@ -5,11 +5,11 @@
 \alias{poplw}
 \title{length_weight}
 \usage{
-length_weight(species_list, fields = NULL, limit = 200,
-  server = getOption("FISHBASE_API", FISHBASE_API), ...)
+length_weight(species_list = NULL, fields = NULL, query = NULL,
+  limit = 200, server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/length_weight.Rd
+++ b/man/length_weight.Rd
@@ -12,8 +12,10 @@ length_weight(species_list = NULL, fields = NULL, query = NULL,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/maturity.Rd
+++ b/man/maturity.Rd
@@ -4,11 +4,11 @@
 \alias{maturity}
 \title{maturity}
 \usage{
-maturity(species_list, fields = NULL, limit = 200,
+maturity(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/maturity.Rd
+++ b/man/maturity.Rd
@@ -11,8 +11,10 @@ maturity(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/morphology.Rd
+++ b/man/morphology.Rd
@@ -11,8 +11,10 @@ morphology(species_list = NULL, fields = NULL, query = NULL,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/morphology.Rd
+++ b/man/morphology.Rd
@@ -4,11 +4,11 @@
 \alias{morphology}
 \title{morphology}
 \usage{
-morphology(species_list, fields = NULL, limit = 200,
-  server = getOption("FISHBASE_API", FISHBASE_API), ...)
+morphology(species_list = NULL, fields = NULL, query = NULL,
+  limit = 200, server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/morphometrics.Rd
+++ b/man/morphometrics.Rd
@@ -11,8 +11,10 @@ morphometrics(species_list = NULL, fields = NULL, query = NULL,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/morphometrics.Rd
+++ b/man/morphometrics.Rd
@@ -4,11 +4,11 @@
 \alias{morphometrics}
 \title{morphometrics}
 \usage{
-morphometrics(species_list, fields = NULL, limit = 200,
-  server = getOption("FISHBASE_API", FISHBASE_API), ...)
+morphometrics(species_list = NULL, fields = NULL, query = NULL,
+  limit = 200, server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/occurrence.Rd
+++ b/man/occurrence.Rd
@@ -4,11 +4,11 @@
 \alias{occurrence}
 \title{occurrence}
 \usage{
-occurrence(species_list, fields = NULL, limit = 200,
-  server = getOption("FISHBASE_API", FISHBASE_API), ...)
+occurrence(species_list = NULL, fields = NULL, query = NULL,
+  limit = 200, server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/occurrence.Rd
+++ b/man/occurrence.Rd
@@ -11,8 +11,10 @@ occurrence(species_list = NULL, fields = NULL, query = NULL,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/oxygen.Rd
+++ b/man/oxygen.Rd
@@ -4,11 +4,11 @@
 \alias{oxygen}
 \title{oxygen}
 \usage{
-oxygen(species_list, fields = NULL, limit = 200,
+oxygen(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/oxygen.Rd
+++ b/man/oxygen.Rd
@@ -11,8 +11,10 @@ oxygen(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/popchar.Rd
+++ b/man/popchar.Rd
@@ -11,8 +11,10 @@ popchar(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/popchar.Rd
+++ b/man/popchar.Rd
@@ -4,11 +4,11 @@
 \alias{popchar}
 \title{popchar}
 \usage{
-popchar(species_list, fields = NULL, limit = 200,
+popchar(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/popgrowth.Rd
+++ b/man/popgrowth.Rd
@@ -11,8 +11,10 @@ popgrowth(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/popgrowth.Rd
+++ b/man/popgrowth.Rd
@@ -4,11 +4,11 @@
 \alias{popgrowth}
 \title{popgrowth}
 \usage{
-popgrowth(species_list, fields = NULL, limit = 200,
+popgrowth(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/popqb.Rd
+++ b/man/popqb.Rd
@@ -4,11 +4,11 @@
 \alias{popqb}
 \title{popqb}
 \usage{
-popqb(species_list, fields = NULL, limit = 200,
+popqb(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/popqb.Rd
+++ b/man/popqb.Rd
@@ -11,8 +11,10 @@ popqb(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/predators.Rd
+++ b/man/predators.Rd
@@ -4,11 +4,11 @@
 \alias{predators}
 \title{predators}
 \usage{
-predators(species_list, fields = NULL, limit = 200,
+predators(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/predators.Rd
+++ b/man/predators.Rd
@@ -11,8 +11,10 @@ predators(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/ration.Rd
+++ b/man/ration.Rd
@@ -4,11 +4,11 @@
 \alias{ration}
 \title{ration}
 \usage{
-ration(species_list, fields = NULL, limit = 200,
+ration(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/ration.Rd
+++ b/man/ration.Rd
@@ -11,8 +11,10 @@ ration(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/reproduction.Rd
+++ b/man/reproduction.Rd
@@ -4,11 +4,11 @@
 \alias{reproduction}
 \title{reproduction}
 \usage{
-reproduction(species_list, fields = NULL, limit = 200,
-  server = getOption("FISHBASE_API", FISHBASE_API), ...)
+reproduction(species_list = NULL, fields = NULL, query = NULL,
+  limit = 200, server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/reproduction.Rd
+++ b/man/reproduction.Rd
@@ -11,8 +11,10 @@ reproduction(species_list = NULL, fields = NULL, query = NULL,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/sci_to_common.Rd
+++ b/man/sci_to_common.Rd
@@ -8,7 +8,7 @@ sci_to_common(species_list, Language = NULL, limit = 1000,
   server = getOption("FISHBASE_API", FISHBASE_API))
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{Language}{the language for the common name, see details.}
 

--- a/man/spawning.Rd
+++ b/man/spawning.Rd
@@ -11,8 +11,10 @@ spawning(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/spawning.Rd
+++ b/man/spawning.Rd
@@ -4,11 +4,11 @@
 \alias{spawning}
 \title{spawning}
 \usage{
-spawning(species_list, fields = NULL, limit = 200,
+spawning(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/species.Rd
+++ b/man/species.Rd
@@ -5,11 +5,11 @@
 \alias{species_info}
 \title{species}
 \usage{
-species(species_list, fields = NULL, limit = 200,
+species(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/species.Rd
+++ b/man/species.Rd
@@ -12,8 +12,10 @@ species(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/speed.Rd
+++ b/man/speed.Rd
@@ -4,11 +4,11 @@
 \alias{speed}
 \title{speed}
 \usage{
-speed(species_list, fields = NULL, limit = 200,
+speed(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/speed.Rd
+++ b/man/speed.Rd
@@ -11,8 +11,10 @@ speed(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/stocks.Rd
+++ b/man/stocks.Rd
@@ -11,8 +11,10 @@ stocks(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/stocks.Rd
+++ b/man/stocks.Rd
@@ -4,11 +4,11 @@
 \alias{stocks}
 \title{stocks}
 \usage{
-stocks(species_list, fields = NULL, limit = 200,
+stocks(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/swimming.Rd
+++ b/man/swimming.Rd
@@ -11,8 +11,10 @@ swimming(species_list = NULL, fields = NULL, query = NULL, limit = 200,
 \item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
+
+\item{query}{a named list specifying specific subsets of fields.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/man/swimming.Rd
+++ b/man/swimming.Rd
@@ -4,11 +4,11 @@
 \alias{swimming}
 \title{swimming}
 \usage{
-swimming(species_list, fields = NULL, limit = 200,
+swimming(species_list = NULL, fields = NULL, query = NULL, limit = 200,
   server = getOption("FISHBASE_API", FISHBASE_API), ...)
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
 all available columns recognized by the parser are returned. This option can be used to the amount

--- a/man/synonyms.Rd
+++ b/man/synonyms.Rd
@@ -18,7 +18,7 @@ will warn if this needs to be increased, otherwise can be left as is.}
 \item{server}{base URL to the FishBase API (by default). For SeaLifeBase, use http://fishbase.ropensci.org/sealifebase}
 
 \item{fields}{a character vector specifying which fields (columns) should be returned. By default,
-all available columns recognized by the parser are returned. This option can be used to the amount
+all available columns recognized by the parser are returned. This option can be used to limit the amount
 of data transfered over the network if only certain columns are needed.}
 }
 \value{

--- a/man/synonyms.Rd
+++ b/man/synonyms.Rd
@@ -10,7 +10,7 @@ synonyms(species_list, limit = 50, server = getOption("FISHBASE_API",
   "WoRMS_ID"))
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}
@@ -44,7 +44,7 @@ synonyms("Callyodon muricatus")
  species_list(SpecCode = x$SpecCode)  # correct: "Labroides dimidiatus"
 
  # See all synonyms using the SpecCode
- species_info("Bolbometopon muricatum", fields="SpecCode")[[1]]
+ species("Bolbometopon muricatum", fields="SpecCode")[[1]]
  synonyms(5537)
  }
 }

--- a/man/validate_names.Rd
+++ b/man/validate_names.Rd
@@ -8,7 +8,7 @@ validate_names(species_list, limit = 50, server = getOption("FISHBASE_API",
   FISHBASE_API))
 }
 \arguments{
-\item{species_list}{A vector of scientific names (each element as "genus species").}
+\item{species_list}{A vector of scientific names (each element as "genus species"). If empty, the table will be loaded up to the limit. This makes it possible to load an entire table without knowledge of the species in the table, thus avoiding uneccesary API calls.}
 
 \item{limit}{The maximum number of matches from a single API call (e.g. per species). Function
 will warn if this needs to be increased, otherwise can be left as is.}

--- a/tests/testthat/test_endpoint.R
+++ b/tests/testthat/test_endpoint.R
@@ -3,3 +3,14 @@ test_that("we can create endpoints with closures", {
   example <- endpoint("species")
   expect_is(example, "function")
 })
+
+test_that("Custom queries give desired result", {
+  
+  country <- endpoint("country")
+  df <- country(query = list(C_Code=440))
+  expect_true(all(df$C_Code == '440'))
+  
+  df <- country("Oreochromis niloticus", query = list(C_Code='050'))
+  expect_true(all(df$C_Code == '050'))
+  
+})

--- a/tests/testthat/test_species.R
+++ b/tests/testthat/test_species.R
@@ -43,5 +43,51 @@ test_that("We can filter on preset fields",{
 
 ## Test wrong species name?
 
+test_that("Fully unmatched species names throw error",{
+  needs_api()  
+  expect_error(species(c("foo", "bar")))
+})
+
+test_that("Partial species match gives warning for missing matches",{
+  needs_api()  
+  expect_warning(species(c("Oreochromis niloticus", "Bolbometopon muricatum","foo", "bar")), 'supplied species names did not match any species in the database')
+})
+
+test_that("Partial species match gives warning for missing matches",{
+  needs_api()  
+  expect_warning(species(c("Oreochromis niloticus", "Bolbometopon muricatum","foo", "bar")), 'supplied species names did not match any species in the database')
+})
+
+test_that("Duplicate species names in species_list returns unique match",{
+  needs_api()  
+  df_s <- species("Oreochromis niloticus")
+  df_d <- species(c("Oreochromis niloticus", "Oreochromis niloticus"))
+  df_dm <- species(c("Oreochromis niloticus", "Oreochromis niloticus", "foo"))
+  expect_equal(nrow(df_s), nrow(df_d))
+  expect_equal(nrow(df_s), nrow(df_dm))
+})
+
+test_that("Sealifebase species are matched",{
+  needs_api()  
+  df_s <- species("Homarus americanus", 
+                  server = "https://fishbase.ropensci.org/sealifebase")
+  df_d <- species(c("Homarus americanus", "Homarus americanus"), 
+                  server = "https://fishbase.ropensci.org/sealifebase")
+  df_dm <- species(c("Homarus americanus", "Homarus americanus", "foo"),
+                  server = "https://fishbase.ropensci.org/sealifebase")
+  
+  expect_equal(nrow(df_s), nrow(df_d))
+  expect_equal(nrow(df_s), nrow(df_dm))
+})
+
+test_that("no species list returns table up to limit",{
+  needs_api()  
+  df_fb <- species(limit=6000)
+  df_slb <- species(limit=6000, server = "https://fishbase.ropensci.org/sealifebase")
+  
+  expect_equal(nrow(df_fb), 6000)
+  expect_equal(nrow(df_slb), 6000)
+})
+
 ## Test wrong server?
 #test_that()


### PR DESCRIPTION
Loop for the endpoint closure with offset since that was giving the same limit error with large species_lists as in #79. I also added a way to load the entire table at once instead of doing loops over each species in the endpoint closure (by omitting the species list in the fxn args), since the repeated API calls make the process very slow when the species list is large - at least for me. In that case, it seems much faster to query the entire table and subset it with the desired species codes afterward. I'm doing that outside of the function at the moment, but could be done within the function I suppose.