### PR TITLE
fix limits for fishbase

### DIFF
--- a/R/load_taxa.R
+++ b/R/load_taxa.R
@@ -39,8 +39,8 @@ load_taxa <- function(update = FALSE, cache = TRUE, server = getOption("FISHBASE
       
       #limit the limit to avoid uneccesary (empty) calls
       limit <- ifelse(server == getOption("FISHBASE_API", FISHBASE_API),  
-                      min(limit,120000L), 
-                      min(limit,33000L))
+                      min(limit,35000L),
+                      min(limit,120000L))
       
       if(limit>5000){
         k <- 0


### PR DESCRIPTION
Limit check was the wrong way around for fishbase and sealifebase, causing unnecessary API calls for fishbase refresh.

Also, had to increase the fishbase limit to above 33 000 to include all taxa.