### PR TITLE
Patch common names & staged install

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: A programmatic interface to <http://www.fishbase.org>, re-written
     supports experimental access to <http://www.sealifebase.org> data, which contains
     nearly 200,000 species records for all types of aquatic life not covered by
     'FishBase.'
-Version: 3.0.0
+Version: 3.0.1
 Encoding: UTF-8
 License: CC0
 Authors@R: c(person("Carl", "Boettiger", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,10 +27,16 @@ And constructed with the following guidelines:
 
 For more information on SemVer, please visit http://semver.org/.
 
-v 3.0
+v 3.0.1
+--------
+
+- patch for upcoming R release with staged installs
+- patch common_names to allow ommitting species_list for full table (#156)
+
+v 3.0.0
 ------
 
-v 3.0 accesses a new static API for `fishbase` with in-memory
+v 3.0.0 accesses a new static API for `fishbase` with in-memory
 memoization that significantly improves performance, particularly
 for large queries.  
 

--- a/R/common_names.R
+++ b/R/common_names.R
@@ -65,12 +65,11 @@ globalVariables(c("ComName", "Language"))
 #' }
 #' @export common_names sci_to_common
 #' @aliases common_names sci_to_common
-common_names <- function(species_list, 
+common_names <- function(species_list = NULL, 
                         server = NULL, 
                         Language = NULL,
                         fields = NULL){
-  
-  left_join(speccodes(species_list), get_comnames(server))
+  species_subset(species_list, get_comnames(server), server)
 }  
 
 

--- a/R/species.R
+++ b/R/species.R
@@ -44,9 +44,18 @@ species <- function(species_list = NULL, fields = NULL,
 
 #species <- endpoint("species", tidy_table = tidy_species_table)
 
+load_species_meta <- memoise::memoise(function(){
+  meta <- system.file("metadata", "species.csv", package="rfishbase")
+  species_meta <- readr::read_csv(meta)
+  row.names(species_meta) <- species_meta$field
+  species_meta
+})
 
 ## helper routine for tidying species data
 tidy_species_table <- function(df) {
+  
+
+  species_meta <- load_species_meta()lib
   # Convert columns to the appropriate class
   for(i in names(df)){
     class <- as.character(species_meta[[i, "class"]])
@@ -71,10 +80,8 @@ tidy_species_table <- function(df) {
   
   df
 }
-## Metadata used by tidy_species_table
-meta <- system.file("metadata", "species.csv", package="rfishbase")
-species_meta <- read.csv(meta)
-row.names(species_meta) <- species_meta$field
+## Metadata used by tidy_species_table, created into data_raw()
+
 
 
 

--- a/R/species.R
+++ b/R/species.R
@@ -55,7 +55,7 @@ load_species_meta <- memoise::memoise(function(){
 tidy_species_table <- function(df) {
   
 
-  species_meta <- load_species_meta()lib
+  species_meta <- load_species_meta()
   # Convert columns to the appropriate class
   for(i in names(df)){
     class <- as.character(species_meta[[i, "class"]])

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   ps: Bootstrap
 
 cache:
-  - C:\RLibrary
+#  - C:\RLibrary
 
 # Adapt as necessary starting from here
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   ps: Bootstrap
 
 cache:
-#  - C:\RLibrary
+  - C:\RLibrary
 
 # Adapt as necessary starting from here
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ init:
         Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
         Import-Module '..\appveyor-tool.ps1'
 
+environment:
+  NOT_CRAN: true
+  USE_RTOOLS: true
+
 install:
   ps: Bootstrap
 


### PR DESCRIPTION
Fixes issue in `common_names()` identified in #156 

Also patches issue for upcoming R release with staged installs, as described in https://developer.r-project.org/Blog/public/2019/02/14/staged-install/index.html.  This fix is courtesy of @gaborcsardi 's much clearer explanation of the problem and the solution:

> It is not only shared libraries, but any kind to reference to the absolute installation path. E.g. my package needed this fix: https://github.com/cran/franc/commit/558792d533c9c35b095824ec16bdb18a35c31c77 because it called `system.file()` at install time,  i.e. outside of a function, and _saved the result_. (Even though it did not use that  result later)

