### PR TITLE
Fix common_to_sci() Language argument being ignored

### DIFF
--- a/R/common_names.R
+++ b/R/common_names.R
@@ -26,12 +26,11 @@ common_to_sci <- function(x,
                           version = "latest",
                           db = NULL){
   
-  comnames <- get_comnames(server, version)
-  subset <- 
+  comnames <- get_comnames(server, version, db = db, lang = Language)
+  subset <-
     purrr::map_dfr(x, function(y){
       y <- stringr::str_to_lower(y)
-      y <- rlang::enquo(y) 
-      dplyr::filter(comnames, grepl(!!y, stringr::str_to_lower(ComName)))
+      dplyr::filter(comnames, grepl(y, stringr::str_to_lower(ComName)))
     })
   
   subset


### PR DESCRIPTION
## Summary

- `common_to_sci()` accepted a `Language` argument but never forwarded it to `get_comnames()`, so lookups always silently used English regardless of the language specified
- Also removes unnecessary `enquo()` wrapping of an already-evaluated string (the value was already a plain character, not an unevaluated expression)

Fixes #275

## Test

```r
# Before fix: returned 0 rows
common_to_sci("Plötze", Language = "German")

# After fix: correctly returns Rutilus rutilus and related species
common_to_sci("Plötze", Language = "German")
#> # A tibble: 6 × 4
#>   Species                    ComName               Language SpecCode
#>   <chr>                      <chr>                 <chr>       <int>
#> 1 Rutilus rutilus            Plötze                German        272
#> ...

common_to_sci("Blankvoorn", Language = "Dutch")
#> # A tibble: 1 × 4
#>   Species         ComName    Language SpecCode
#>   <chr>           <chr>      <chr>       <int>
#> 1 Rutilus rutilus Blankvoorn Dutch         272
```