### PR TITLE
Correct the 2026 release tag: 26.06, not 26.07

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,11 +26,11 @@ For more information on SemVer, please visit http://semver.org/.
 v 5.0.4
 -------
 
-Data updated to the 2026 releases: FishBase `v26.07` and SeaLifeBase `v26.04`.
-These are now what `version = "latest"` resolves to. Earlier releases remain
-available via `available_releases()`. The new snapshots add 6 tables to
-FishBase (222 total) and 3 to SeaLifeBase (202 total); no previously published
-table was dropped.
+Data updated to the 2026 releases of FishBase and SeaLifeBase, both tagged
+`v26.06`. These are now what `version = "latest"` resolves to. Earlier
+releases remain available via `available_releases()`. The new snapshots add
+6 tables to FishBase (222 total) and 3 to SeaLifeBase (202 total); no
+previously published table was dropped.
 
 The workflow for importing a new database dump and publishing it to Source
 Cooperative is now scripted and documented in `data-raw/README.md`.

--- a/data-raw/README.md
+++ b/data-raw/README.md
@@ -7,7 +7,7 @@ FishBase and SeaLifeBase send `fbapp.7z` / `slbapp.7z` (7z-compressed
 # 1. drop the dumps in imports/ (git-ignored, excluded from the build), then
 bash data-raw/import_dumps.sh /tmp/fishbase-import
 # 2. read the verification summary, then publish (args are fb and slb versions)
-bash data-raw/upload.sh /tmp/fishbase-import 26.07 26.04
+bash data-raw/upload.sh /tmp/fishbase-import 26.06 26.06
 ```
 
 `import_dumps.sh` unpacks the dumps into a throwaway local MariaDB instance and
@@ -21,7 +21,7 @@ Nothing in the R package needs to change to ship a release:
 `available_releases()` reads the bucket and `version = "latest"` picks the
 highest version present.
 
-Version tags encode the *snapshot date* of the dump (`v26.07` = July 2026).
+Version tags encode the *snapshot date* of the dump (`v26.06` = June 2026).
 The two servers can carry different tags when their dumps arrive at different
 times, since releases are listed per server.
 

--- a/data-raw/upload.sh
+++ b/data-raw/upload.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 # Publish a parquet export to Source Cooperative.
 #
-# Version tags encode the snapshot date of the dump (v26.07 = July 2026).  The
+# Version tags encode the snapshot date of the dump (v26.06 = June 2026).  The
 # two servers can carry different tags when their dumps arrive at different
 # times; `available_releases()` lists each server independently.
 #
 # Requires an `rclone` remote named `source` holding Source Cooperative creds.
 #
 # Usage:  bash data-raw/upload.sh <workdir> <fb-version> <slb-version>
-#   e.g.  bash data-raw/upload.sh /tmp/fishbase-import 26.07 26.04
+#   e.g.  bash data-raw/upload.sh /tmp/fishbase-import 26.06 26.06
 set -euo pipefail
 
-W="${1:?workdir}"; FB="${2:?fb version, e.g. 26.07}"; SLB="${3:?slb version, e.g. 26.04}"
+W="${1:?workdir}"; FB="${2:?fb version, e.g. 26.06}"; SLB="${3:?slb version, e.g. 26.06}"
 DEST="source:us-west-2.opendata.source.coop/cboettig/fishbase"
 
 # --s3-no-check-bucket: the publishing credentials can write the prefix but are


### PR DESCRIPTION
The 2026 data release was published under `fb/v26.07` and `slb/v26.04`, but both
dumps are June 2026 snapshots. Both should be `v26.06`.

## Already done on Source Cooperative

The bucket has been corrected ahead of this PR, since the docs describe what is
published there:

| server | was | now | files |
|---|---|---|---|
| FishBase | `fb/v26.07` | `fb/v26.06` | 222 |
| SeaLifeBase | `slb/v26.04` | `slb/v26.06` | 202 |

Contents were copied server-side and verified with `rclone check --checksum`
(`0 differences found` on both, re-run immediately before removal), then the old
prefixes were purged.

Removing `fb/v26.07` was necessary rather than tidy-up: `available_releases()`
sorts the tags it finds and `version = "latest"` takes the highest, so while
`26.07` remained it kept winning over the correct `26.06`. The trade-off is that
anyone who pinned `version = "26.07"` or `version = "26.04"` in the days since
the release now gets an error instead of silently mislabeled data.

After the change:

```
fishbase:    19.04 21.06 23.01 23.05 24.07 25.04 26.06
sealifebase: 19.04       23.01 23.05 24.07 25.04 26.06

fb  species rows @ latest:   36,763
slb species rows @ latest:  102,727
```

## This PR

Documentation only — `NEWS.md`, `data-raw/README.md`, `data-raw/upload.sh`. No
package code changes, because nothing pins a version: `available_releases()`
reads the bucket at runtime and `"latest"` is computed from that listing.

## No CRAN release needed

CRAN currently has 5.0.3; the 5.0.4 NEWS entry naming the wrong tag has never
shipped. Installed copies of the package pick up `26.06` automatically on their
next call, since the release list is read from the bucket rather than baked into
the package.
